### PR TITLE
[1.3.1] Add option to display battery info in the tile's title

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "com.cominatyou.batterytile"
         minSdk 29
         targetSdk 33
-        versionCode 5
-        versionName "1.3.0"
+        versionCode 6
+        versionName "1.3.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/cominatyou/batterytile/preferences/PreferencesBottomSheet.java
+++ b/app/src/main/java/com/cominatyou/batterytile/preferences/PreferencesBottomSheet.java
@@ -72,6 +72,13 @@ public class PreferencesBottomSheet extends BottomSheetDialogFragment {
             }
         });
 
+        binding.infoInTitleLayout.setOnClickListener(self -> binding.infoInTitleSwitch.toggle());
+
+        binding.infoInTitleSwitch.setOnCheckedChangeListener((self, state) -> requireContext().getSharedPreferences("preferences", Context.MODE_PRIVATE)
+                .edit()
+                .putBoolean("infoInTitle", state)
+                .apply());
+
         if (requireContext().getSharedPreferences("preferences", Context.MODE_PRIVATE).getBoolean("emulatePowerSaveTile", false)) {
             binding.emulatePowerSaveTilePreferenceSwitch.setChecked(true);
             forceTappableTile(true);
@@ -81,6 +88,10 @@ public class PreferencesBottomSheet extends BottomSheetDialogFragment {
         }
 
         showDialog = true;
+
+        if (requireContext().getSharedPreferences("preferences", Context.MODE_PRIVATE).getBoolean("infoInTitle", false)) {
+            binding.infoInTitleSwitch.setChecked(true);
+        }
 
         return binding.getRoot();
     }

--- a/app/src/main/res/layout/bottom_sheet_preferences.xml
+++ b/app/src/main/res/layout/bottom_sheet_preferences.xml
@@ -107,4 +107,47 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/tappable_tile_layout"
+        app:layout_constraintStart_toStartOf="parent"
+        android:paddingVertical="16dp"
+        android:clickable="true"
+        android:background="?attr/selectableItemBackground"
+        android:id="@+id/info_in_title_layout">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            android:textSize="20sp"
+            android:layout_marginStart="24dp"
+            android:id="@+id/info_in_title_title"
+            android:textColor="?android:textColorPrimary"
+            android:text="@string/info_in_title_option_title" />
+
+        <TextView
+            android:id="@+id/info_in_title_description"
+            android:layout_width="250dp"
+            android:layout_marginTop="1dp"
+            android:textSize="14sp"
+            android:layout_height="wrap_content"
+            android:text="@string/info_in_title_option_description"
+            android:textColor="?android:textColorSecondary"
+            app:layout_constraintStart_toStartOf="@+id/info_in_title_title"
+            app:layout_constraintTop_toBottomOf="@id/info_in_title_title" />
+
+        <com.google.android.material.materialswitch.MaterialSwitch
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/info_in_title_switch"
+            android:layout_marginEnd="24dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,6 @@
     <string name="power_save_tile_unavailable_subtitle">Unavailable</string>
     <string name="power_save_tile_warning_title">Hold up! This is important.</string>
     <string name="power_save_system_warning_description">Android doesn\'t natively support apps changing the state of Battery Saver, and as such, this feature is experimental as of now.\n\nThe workaround the app uses can cause the Android System to no longer be able to control the Battery Saver setting after tapping the tile, meaning that things like the system Battery Saver tile won\'t work.\n\nIf you encounter this, tapping this tile (the tile from this app) again to restore the Battery Saver setting to its previous state should fix it.</string>
+    <string name="info_in_title_option_title">Show battery info in tile title</string>
+    <string name="info_in_title_option_description">Show info about the battery in the tile\'s title. Turn this on if you only see \"Battery\" after adding the tile to the quick settings panel.</string>
 </resources>


### PR DESCRIPTION
Resolves #3: Adds the ability to display the battery info in the tile's title for devices that don't support tile subtitles.